### PR TITLE
Remove generic type / object styles note

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -111,15 +111,19 @@ const Image1 = styled('div')({
 
 // Or with a generic type
 
-const Image1 = styled('div')<ImageProps>({
+const Image2 = styled('div')<ImageProps>`
+  width: ${props => props.width};
+  background: url(${props => props.src}) center center;
+  background-size: contain;
+`
+
+const Image3 = styled('div')<ImageProps>({
   backgroundSize: 'contain',
 }, props => ({
   width: props.width;
   background: `url(${props.src}) center center`,
 }));
 ```
-
-* The generic type version only works with object styles due to https://github.com/Microsoft/TypeScript/issues/11947.
 
 ### React Components
 


### PR DESCRIPTION
**What**:

Remove the generic type / object styles note in the TypeScript doc.

Also add an example using the tagged template style.

<!-- Why are these changes necessary? -->
**Why**:

The generic type now works with the tagged template style, so the
note is no longer necessary.

https://github.com/Microsoft/TypeScript/issues/11947 is fixed by
https://github.com/Microsoft/TypeScript/pull/23430.

<!-- How were these changes implemented? -->
**How**:

Manually edited the `docs/typescript.md` document.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [ ] Tests N/A
- [ ] Code complete N/A

<!-- feel free to add additional comments -->

<!-- Please add a `Tag:` prefixed label from the labels so that this PR shows up in the changelog -->
